### PR TITLE
Add cryptography as a dependency as it is necessay since snmpsim 1.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.14-slim
 
-RUN pip install --no-cache-dir -I snmpsim
+RUN pip install --no-cache-dir -I snmpsim cryptography
 
 # The emulator needs to be run as a non-root user. The snmpsim variation
 # modules (like writecache) are installed off the search path, so copy them


### PR DESCRIPTION
The dependency is not strict, as it is possible to do without the cryptography package and install all packages manually. However, the package comes with everything needed to run the various encryption algorithms.

Fix the problem with the upgrade of snmpsim 1.2.1 with the `snmpwalk Decryption error`.